### PR TITLE
Get one rep max argument

### DIFF
--- a/commands/3rm.js
+++ b/commands/3rm.js
@@ -11,20 +11,20 @@ const controller = [
     message: "Choose an exercise",
     choices: exercises
   },
-  { type: "input", name: "weight", message: "What's your new one rep max?" }
+  { type: "input", name: "weight", message: "What's your new three rep max?" }
 ];
 
 module.exports = function() {
   inquirer.prompt(controller).then(function(answers) {
     const fileAsJSON = fetchDB();
 
-    fileAsJSON.onerm[answers.exercise] = answers.weight;
+    fileAsJSON.threerm[answers.exercise] = answers.weight;
 
     updateDB(fileAsJSON);
 
     console.log(
       colors.green(
-        "Logged " + answers.weight + " as new " + answers.exercise + " one rep max."
+        "Logged " + answers.weight + " as new " + answers.exercise + " three rep max."
       )
     );
   });

--- a/commands/5rm.js
+++ b/commands/5rm.js
@@ -11,20 +11,20 @@ const controller = [
     message: "Choose an exercise",
     choices: exercises
   },
-  { type: "input", name: "weight", message: "What's your new one rep max?" }
+  { type: "input", name: "weight", message: "What's your new five rep max?" }
 ];
 
 module.exports = function() {
   inquirer.prompt(controller).then(function(answers) {
     const fileAsJSON = fetchDB();
 
-    fileAsJSON.onerm[answers.exercise] = answers.weight;
+    fileAsJSON.fiverm[answers.exercise] = answers.weight;
 
     updateDB(fileAsJSON);
 
     console.log(
       colors.green(
-        "Logged " + answers.weight + " as new " + answers.exercise + " one rep max."
+        "Logged " + answers.weight + " as new " + answers.exercise + " five rep max."
       )
     );
   });

--- a/commands/getonerm.js
+++ b/commands/getonerm.js
@@ -1,0 +1,30 @@
+const { fetchDB  } = require("../dbUtils/fetchDB");
+const { updateDB  } = require("../dbUtils/updateDB");
+const inquirer = require("inquirer");
+const colors = require("colors");
+const { exercises  } = require("../options");
+
+const controller = [
+  {
+      type: "list",
+      name: "exercise",
+      message: "Choose an exercise",
+      choices: exercises
+                    
+  }
+    
+];
+
+exports.getOneRM = function() {
+    inquirer.prompt(controller).then(function(answers) {
+      const fileAsJSON = fetchDB();
+
+      oneRM = fileAsJSON.onerm[answers.exercise];
+      
+      console.log(
+        colors.green(
+          "Current one rep max for " + answers.exercise + " is " + oneRM + "."
+        )
+    );
+  });
+};

--- a/commands/getonerm.js
+++ b/commands/getonerm.js
@@ -3,6 +3,7 @@ const { updateDB  } = require("../dbUtils/updateDB");
 const inquirer = require("inquirer");
 const colors = require("colors");
 const { exercises  } = require("../options");
+const program = require("commander");
 
 const controller = [
   {
@@ -15,7 +16,37 @@ const controller = [
     
 ];
 
-exports.getOneRM = function() {
+getAllOneRM = function() {
+          const fileAsJSON = fetchDB();
+
+          benchOneRM = fileAsJSON.onerm["bench press"];
+          squatOneRM = fileAsJSON.onerm["squat"];
+          deadliftOneRM = fileAsJSON.onerm["deadlift"];
+          ohpOneRM = fileAsJSON.onerm["overhead press"];
+          rowOneRM = fileAsJSON.onerm["bent over row"];
+
+          console.log(
+              colors.green(
+                            "Bench Press 1RM: " + benchOneRM + "\n" +
+                            "Squat 1RM: " + squatOneRM + "\n" +
+                            "Deadlift 1RM: " + deadliftOneRM + "\n" +
+                            "Overhead Press 1RM: " + ohpOneRM + "\n" + 
+                            "Bent Over Row 1RM: " + rowOneRM + "\n" 
+  
+                          
+              )
+                  
+          );
+      
+};
+
+
+
+exports.getOneRM = function(options) {
+    if (options.all) {
+        getAllOneRM();
+    } else {
+
     inquirer.prompt(controller).then(function(answers) {
       const fileAsJSON = fetchDB();
 
@@ -27,4 +58,4 @@ exports.getOneRM = function() {
         )
     );
   });
-};
+}};

--- a/commands/getonerm.js
+++ b/commands/getonerm.js
@@ -42,10 +42,21 @@ getAllOneRM = function() {
 
 
 
-exports.getOneRM = function(options) {
+exports.getOneRM = function(exerciseArg, options) {
     if (options.all) {
         getAllOneRM();
-    } else {
+    } else if (exerciseArg) {
+        const fileAsJSON = fetchDB();
+
+        oneRM = fileAsJSON.onerm[exerciseArg];
+        console.log(
+                colors.green(
+                  "Current one rep max for " + exerciseArg + " is " + oneRM + "."
+                )
+            );
+
+    }
+    else {
 
     inquirer.prompt(controller).then(function(answers) {
       const fileAsJSON = fetchDB();

--- a/commands/log.js
+++ b/commands/log.js
@@ -2,6 +2,8 @@ const inquirer = require("inquirer");
 const colors = require("colors");
 const { types } = require("../options");
 const onerm = require("./1rm");
+const threerm = require("./3rm");
+const fiverm = require("./5rm");
 const meal = require("./meal");
 const sleep = require("./sleep");
 const workout = require("./workout");
@@ -23,6 +25,12 @@ exports.log = () => {
     switch (type) {
       case "1rm":
         onerm();
+        break;
+      case "3rm":
+        threerm();
+        break;
+      case "5rm":
+        fiverm();
         break;
       case "meal":
         meal();

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ if (process.argv.length < 3) {
 }
 
 program
-  .command("onerm")
+  .command('onerm [exerciseArg]')
   .alias("one")
   .option('-a, --all','retrieve 1RM for all exercises')
   .description("Fetch one rep max of exercise")
@@ -28,8 +28,8 @@ program
   .action(
       // if -a flag is set, return one rep max for all lifts
       
-          function(options) {
-              getOneRM(options);
+          function(exerciseArg, options) {
+              getOneRM(exerciseArg, options);
     })
 .parse(process.argv);
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node --harmony
 const program = require("commander");
 const { log } = require("./commands/log");
+const { getOneRM } = require("./commands/getonerm")
 
 program.version("0.0.1").description("Fitness logger for developers");
 
@@ -11,6 +12,15 @@ program
 
   .action(function() {
     log();
+  });
+
+program
+  .command("onerm")
+  .alias("one")
+  .description("Fetch one rep max of exercise")
+
+  .action(function() {
+    getOneRM();
   });
 
 if (process.argv.length < 3) {

--- a/index.js
+++ b/index.js
@@ -14,14 +14,24 @@ program
     log();
   });
 
+if (process.argv.length < 3) {
+      log();
+
+}
+
 program
   .command("onerm")
   .alias("one")
+  .option('-a, --all','retrieve 1RM for all exercises')
   .description("Fetch one rep max of exercise")
 
-  .action(function() {
-    getOneRM();
-  });
+  .action(
+      // if -a flag is set, return one rep max for all lifts
+      
+          function(options) {
+              getOneRM(options);
+    })
+.parse(process.argv);
 
 if (process.argv.length < 3) {
   log();

--- a/options.js
+++ b/options.js
@@ -6,4 +6,4 @@ exports.exercises = [
   "bent over row"
 ];
 
-exports.types = ["1rm", "meal", "sleep", "workout"];
+exports.types = ["1rm", "3rm", "5rm", "meal", "sleep", "workout"];

--- a/setup/setupdb.js
+++ b/setup/setupdb.js
@@ -8,6 +8,20 @@ const intialDB = `{
     "deadlift": 0,
     "overhead press": 0,
     "bent over row": 0
+  },
+  "threerm": {
+    "bench press": 0,
+    "squat": 0,
+    "deadlift": 0,
+    "overhead press": 0,
+    "bent over row": 0
+  },
+  "fiverm": {
+    "bench press": 0,
+    "squat": 0,
+    "deadlift": 0,
+    "overhead press": 0,
+    "bent over row": 0
   }
 }`;
 


### PR DESCRIPTION
Lookig at index.js,  I'm not seeing a way to grab the 1RM of one specific lift.  I've added an argument flag to one rm to allow users to retrieve the 1RM of a single lift

Output of argument:

```
darwin@DTP:fit-cli λ fit log
? What do you want to log? 1rm
Logging 1rm...
? Choose an exercise bench press
? What's your new one rep max? 225
Logged 225 as new bench press one rep max.
darwin@DTP:fit-cli λ fit log
? What do you want to log? 1rm
Logging 1rm...
? Choose an exercise squat
? What's your new one rep max? 315
Logged 315 as new squat one rep max.
darwin@DTP:fit-cli λ fit log
? What do you want to log? 1rm
Logging 1rm...
? Choose an exercise deadlift
? What's your new one rep max? 405
Logged 405 as new deadlift one rep max.
darwin@DTP:fit-cli λ fit log
? What do you want to log? 1rm
Logging 1rm...
? Choose an exercise overhead press
? What's your new one rep max? 135
Logged 135 as new overhead press one rep max.
darwin@DTP:fit-cli λ fit log
? What do you want to log? 1rm
Logging 1rm...
? Choose an exercise bent over row
? What's your new one rep max? 275
Logged 275 as new bent over row one rep max.
darwin@DTP:fit-cli λ fit onerm deadlift
Current one rep max for deadlift is 405.
darwin@DTP:fit-cli λ fit onerm "bench press"
Current one rep max for bench press is 225.
darwin@DTP:fit-cli λ
```
