### PR TITLE
Missing 3rm 5rm functionality

### DIFF
--- a/commands/3rm.js
+++ b/commands/3rm.js
@@ -11,20 +11,20 @@ const controller = [
     message: "Choose an exercise",
     choices: exercises
   },
-  { type: "input", name: "weight", message: "What's your new one rep max?" }
+  { type: "input", name: "weight", message: "What's your new three rep max?" }
 ];
 
 module.exports = function() {
   inquirer.prompt(controller).then(function(answers) {
     const fileAsJSON = fetchDB();
 
-    fileAsJSON.onerm[answers.exercise] = answers.weight;
+    fileAsJSON.threerm[answers.exercise] = answers.weight;
 
     updateDB(fileAsJSON);
 
     console.log(
       colors.green(
-        "Logged " + answers.weight + " as new " + answers.exercise + " one rep max."
+        "Logged " + answers.weight + " as new " + answers.exercise + " three rep max."
       )
     );
   });

--- a/commands/5rm.js
+++ b/commands/5rm.js
@@ -11,20 +11,20 @@ const controller = [
     message: "Choose an exercise",
     choices: exercises
   },
-  { type: "input", name: "weight", message: "What's your new one rep max?" }
+  { type: "input", name: "weight", message: "What's your new five rep max?" }
 ];
 
 module.exports = function() {
   inquirer.prompt(controller).then(function(answers) {
     const fileAsJSON = fetchDB();
 
-    fileAsJSON.onerm[answers.exercise] = answers.weight;
+    fileAsJSON.fiverm[answers.exercise] = answers.weight;
 
     updateDB(fileAsJSON);
 
     console.log(
       colors.green(
-        "Logged " + answers.weight + " as new " + answers.exercise + " one rep max."
+        "Logged " + answers.weight + " as new " + answers.exercise + " five rep max."
       )
     );
   });

--- a/commands/getfiverm.js
+++ b/commands/getfiverm.js
@@ -1,0 +1,72 @@
+const { fetchDB  } = require("../dbUtils/fetchDB");
+const { updateDB  } = require("../dbUtils/updateDB");
+const inquirer = require("inquirer");
+const colors = require("colors");
+const { exercises  } = require("../options");
+const program = require("commander");
+
+const controller = [
+  {
+      type: "list",
+      name: "exercise",
+      message: "Choose an exercise",
+      choices: exercises
+                    
+  }
+    
+];
+
+getAllFiveRM = function() {
+          const fileAsJSON = fetchDB();
+
+          benchFiveRM = fileAsJSON.fiverm["bench press"];
+          squatFiveRM = fileAsJSON.fiverm["squat"];
+          deadliftFiveRM = fileAsJSON.fiverm["deadlift"];
+          ohpFiveRM = fileAsJSON.fiverm["overhead press"];
+          rowFiveRM = fileAsJSON.fiverm["bent over row"];
+
+          console.log(
+              colors.green(
+                            "Bench Press 5RM: " + benchFiveRM + "\n" +
+                            "Squat 5RM: " + squatFiveRM + "\n" +
+                            "Deadlift 5RM: " + deadliftFiveRM + "\n" +
+                            "Overhead Press 5RM: " + ohpFiveRM + "\n" + 
+                            "Bent Over Row 5RM: " + rowFiveRM + "\n" 
+  
+                          
+              )
+                  
+          );
+      
+};
+
+
+
+exports.getFiveRM = function(exerciseArg, options) {
+    if (options.all) {
+        getAllFiveRM();
+    } else if (exerciseArg) {
+        const fileAsJSON = fetchDB();
+
+        fiveRM = fileAsJSON.fiverm[exerciseArg];
+        console.log(
+                colors.green(
+                  "Current five rep max for " + exerciseArg + " is " + fiveRM + "."
+                )
+            );
+
+    }
+    else {
+
+    inquirer.prompt(controller).then(function(answers) {
+      const fileAsJSON = fetchDB();
+
+      fiveRM = fileAsJSON.fiverm[answers.exercise];
+      
+      console.log(
+        colors.green(
+          "Current five rep max for " + answers.exercise + " is " + fiveRM + "."
+        )
+    );
+  });
+}};

--- a/commands/getonerm.js
+++ b/commands/getonerm.js
@@ -1,0 +1,30 @@
+const { fetchDB  } = require("../dbUtils/fetchDB");
+const { updateDB  } = require("../dbUtils/updateDB");
+const inquirer = require("inquirer");
+const colors = require("colors");
+const { exercises  } = require("../options");
+
+const controller = [
+  {
+      type: "list",
+      name: "exercise",
+      message: "Choose an exercise",
+      choices: exercises
+                    
+  }
+    
+];
+
+exports.getOneRM = function() {
+    inquirer.prompt(controller).then(function(answers) {
+      const fileAsJSON = fetchDB();
+
+      oneRM = fileAsJSON.onerm[answers.exercise];
+      
+      console.log(
+        colors.green(
+          "Current one rep max for " + answers.exercise + " is " + oneRM + "."
+        )
+    );
+  });
+};

--- a/commands/getonerm.js
+++ b/commands/getonerm.js
@@ -3,6 +3,7 @@ const { updateDB  } = require("../dbUtils/updateDB");
 const inquirer = require("inquirer");
 const colors = require("colors");
 const { exercises  } = require("../options");
+const program = require("commander");
 
 const controller = [
   {
@@ -15,7 +16,37 @@ const controller = [
     
 ];
 
-exports.getOneRM = function() {
+getAllOneRM = function() {
+          const fileAsJSON = fetchDB();
+
+          benchOneRM = fileAsJSON.onerm["bench press"];
+          squatOneRM = fileAsJSON.onerm["squat"];
+          deadliftOneRM = fileAsJSON.onerm["deadlift"];
+          ohpOneRM = fileAsJSON.onerm["overhead press"];
+          rowOneRM = fileAsJSON.onerm["bent over row"];
+
+          console.log(
+              colors.green(
+                            "Bench Press 1RM: " + benchOneRM + "\n" +
+                            "Squat 1RM: " + squatOneRM + "\n" +
+                            "Deadlift 1RM: " + deadliftOneRM + "\n" +
+                            "Overhead Press 1RM: " + ohpOneRM + "\n" + 
+                            "Bent Over Row 1RM: " + rowOneRM + "\n" 
+  
+                          
+              )
+                  
+          );
+      
+};
+
+
+
+exports.getOneRM = function(options) {
+    if (options.all) {
+        getAllOneRM();
+    } else {
+
     inquirer.prompt(controller).then(function(answers) {
       const fileAsJSON = fetchDB();
 
@@ -27,4 +58,4 @@ exports.getOneRM = function() {
         )
     );
   });
-};
+}};

--- a/commands/getonerm.js
+++ b/commands/getonerm.js
@@ -42,10 +42,21 @@ getAllOneRM = function() {
 
 
 
-exports.getOneRM = function(options) {
+exports.getOneRM = function(exerciseArg, options) {
     if (options.all) {
         getAllOneRM();
-    } else {
+    } else if (exerciseArg) {
+        const fileAsJSON = fetchDB();
+
+        oneRM = fileAsJSON.onerm[exerciseArg];
+        console.log(
+                colors.green(
+                  "Current one rep max for " + exerciseArg + " is " + oneRM + "."
+                )
+            );
+
+    }
+    else {
 
     inquirer.prompt(controller).then(function(answers) {
       const fileAsJSON = fetchDB();

--- a/commands/getthreerm.js
+++ b/commands/getthreerm.js
@@ -1,0 +1,72 @@
+const { fetchDB  } = require("../dbUtils/fetchDB");
+const { updateDB  } = require("../dbUtils/updateDB");
+const inquirer = require("inquirer");
+const colors = require("colors");
+const { exercises  } = require("../options");
+const program = require("commander");
+
+const controller = [
+  {
+      type: "list",
+      name: "exercise",
+      message: "Choose an exercise",
+      choices: exercises
+                    
+  }
+    
+];
+
+getAllThreeRM = function() {
+          const fileAsJSON = fetchDB();
+
+          benchThreeRM = fileAsJSON.threerm["bench press"];
+          squatThreeRM = fileAsJSON.threerm["squat"];
+          deadliftThreeRM = fileAsJSON.threerm["deadlift"];
+          ohpThreeRM = fileAsJSON.threerm["overhead press"];
+          rowThreeRM = fileAsJSON.threerm["bent over row"];
+
+          console.log(
+              colors.green(
+                            "Bench Press 3RM: " + benchThreeRM + "\n" +
+                            "Squat 3RM: " + squatThreeRM + "\n" +
+                            "Deadlift 3RM: " + deadliftThreeRM + "\n" +
+                            "Overhead Press 3RM: " + ohpThreeRM + "\n" + 
+                            "Bent Over Row 3RM: " + rowThreeRM + "\n" 
+  
+                          
+              )
+                  
+          );
+      
+};
+
+
+
+exports.getThreeRM = function(exerciseArg, options) {
+    if (options.all) {
+        getAllThreeRM();
+    } else if (exerciseArg) {
+        const fileAsJSON = fetchDB();
+
+        threeRM = fileAsJSON.threerm[exerciseArg];
+        console.log(
+                colors.green(
+                  "Current three rep max for " + exerciseArg + " is " + threeRM + "."
+                )
+            );
+
+    }
+    else {
+
+    inquirer.prompt(controller).then(function(answers) {
+      const fileAsJSON = fetchDB();
+
+      threeRM = fileAsJSON.threerm[answers.exercise];
+      
+      console.log(
+        colors.green(
+          "Current three rep max for " + answers.exercise + " is " + threeRM + "."
+        )
+    );
+  });
+}};

--- a/commands/log.js
+++ b/commands/log.js
@@ -2,6 +2,8 @@ const inquirer = require("inquirer");
 const colors = require("colors");
 const { types } = require("../options");
 const onerm = require("./1rm");
+const threerm = require("./3rm");
+const fiverm = require("./5rm");
 const meal = require("./meal");
 const sleep = require("./sleep");
 const workout = require("./workout");
@@ -23,6 +25,12 @@ exports.log = () => {
     switch (type) {
       case "1rm":
         onerm();
+        break;
+      case "3rm":
+        threerm();
+        break;
+      case "5rm":
+        fiverm();
         break;
       case "meal":
         meal();

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ if (process.argv.length < 3) {
 }
 
 program
-  .command("onerm")
+  .command('onerm [exerciseArg]')
   .alias("one")
   .option('-a, --all','retrieve 1RM for all exercises')
   .description("Fetch one rep max of exercise")
@@ -28,8 +28,8 @@ program
   .action(
       // if -a flag is set, return one rep max for all lifts
       
-          function(options) {
-              getOneRM(options);
+          function(exerciseArg, options) {
+              getOneRM(exerciseArg, options);
     })
 .parse(process.argv);
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 const program = require("commander");
 const { log } = require("./commands/log");
 const { getOneRM } = require("./commands/getonerm")
+const { getThreeRM } = require("./commands/getthreerm")
+const { getFiveRM } = require("./commands/getfiverm")
 
 program.version("0.0.1").description("Fitness logger for developers");
 
@@ -31,10 +33,32 @@ program
           function(exerciseArg, options) {
               getOneRM(exerciseArg, options);
     })
-.parse(process.argv);
 
-if (process.argv.length < 3) {
-  log();
-}
+program
+  .command('threerm [exerciseArg]')
+  .alias("three")
+  .option('-a, --all','retrieve 3RM for all exercises')
+  .description("Fetch three rep max of exercise")
+
+  .action(
+      // if -a flag is set, return one rep max for all lifts
+      
+          function(exerciseArg, options) {
+              getThreeRM(exerciseArg, options);
+    })
+
+program
+  .command('fiverm [exerciseArg]')
+  .alias("five")
+  .option('-a, --all','retrieve 5RM for all exercises')
+  .description("Fetch five rep max of exercise")
+
+  .action(
+      // if -a flag is set, return one rep max for all lifts
+      
+          function(exerciseArg, options) {
+              getFiveRM(exerciseArg, options);
+    })
+
 
 program.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node --harmony
 const program = require("commander");
 const { log } = require("./commands/log");
+const { getOneRM } = require("./commands/getonerm")
 
 program.version("0.0.1").description("Fitness logger for developers");
 
@@ -11,6 +12,15 @@ program
 
   .action(function() {
     log();
+  });
+
+program
+  .command("onerm")
+  .alias("one")
+  .description("Fetch one rep max of exercise")
+
+  .action(function() {
+    getOneRM();
   });
 
 if (process.argv.length < 3) {

--- a/index.js
+++ b/index.js
@@ -14,14 +14,24 @@ program
     log();
   });
 
+if (process.argv.length < 3) {
+      log();
+
+}
+
 program
   .command("onerm")
   .alias("one")
+  .option('-a, --all','retrieve 1RM for all exercises')
   .description("Fetch one rep max of exercise")
 
-  .action(function() {
-    getOneRM();
-  });
+  .action(
+      // if -a flag is set, return one rep max for all lifts
+      
+          function(options) {
+              getOneRM(options);
+    })
+.parse(process.argv);
 
 if (process.argv.length < 3) {
   log();

--- a/options.js
+++ b/options.js
@@ -6,4 +6,4 @@ exports.exercises = [
   "bent over row"
 ];
 
-exports.types = ["1rm", "meal", "sleep", "workout"];
+exports.types = ["1rm", "3rm", "5rm", "meal", "sleep", "workout"];

--- a/setup/setupdb.js
+++ b/setup/setupdb.js
@@ -8,6 +8,20 @@ const intialDB = `{
     "deadlift": 0,
     "overhead press": 0,
     "bent over row": 0
+  },
+  "threerm": {
+    "bench press": 0,
+    "squat": 0,
+    "deadlift": 0,
+    "overhead press": 0,
+    "bent over row": 0
+  },
+  "fiverm": {
+    "bench press": 0,
+    "squat": 0,
+    "deadlift": 0,
+    "overhead press": 0,
+    "bent over row": 0
   }
 }`;
 


### PR DESCRIPTION
Adding commands to retrieve 1RM, 3RM, and 5RM of lifts.

Here's how a user can query for their maxes

```
$ fit onerm  // will open a prompt that asks user which exercise 1RM they want to see
$ fit threerm --all // this will list the 3RM for all five lifts
$ fit fiverm squat // this will display the 5RM for a user's squat
$ fit onerm "bench press" // quotes are needed if the lift has a space in the name
```